### PR TITLE
Fix error reporting on newer ponyc versions

### DIFF
--- a/ast/pass.pony
+++ b/ast/pass.pony
@@ -83,6 +83,7 @@ struct _PassOpt
   var abi: Pointer[U8] ref = abi.create()
   var cpu: Pointer[U8] ref = cpu.create()
   var features: Pointer[U8] ref = features.create()
+  var serialise_id_hash_key: Pointer[U8] ref = serialise_id_hash_key.create()
 
   embed check: _Typecheck = check.create()
   var plugins: Pointer[_Plugins] ref = plugins.create()

--- a/examples/main.pony
+++ b/examples/main.pony
@@ -5,4 +5,8 @@ actor Main
 
   fun ref none(param: String = "foo"): Main =>
     [as U8:]
+    this.bla()
+    bla()
     this
+
+  fun bla(): Bool => true

--- a/tests/compile_errors_01/main.pony
+++ b/tests/compile_errors_01/main.pony
@@ -1,0 +1,6 @@
+actor Main
+  new create(env: Env) =>
+    this.frobnicate()
+
+  be snotricate(badger: Badger) =>
+    foo = "Bar"

--- a/tests/compile_errors_02/main.pony
+++ b/tests/compile_errors_02/main.pony
@@ -1,0 +1,8 @@
+actor Main
+  new create(env: Env) =>
+    this.frobnicate()
+
+  be snotricate(badger: Badger) =>
+    foo = "Bar"
+
+class Badger

--- a/tests/compile_errors_03/main.pony
+++ b/tests/compile_errors_03/main.pony
@@ -1,0 +1,8 @@
+actor Main
+  new create(env: Env) =>
+    this.frobnicate()
+
+  be snotricate(badger: Badger iso) =>
+    foo = "Bar"
+
+class Badger

--- a/tests/compile_errors_04/main.pony
+++ b/tests/compile_errors_04/main.pony
@@ -1,0 +1,1 @@
+use "unfinished


### PR DESCRIPTION
The pass_opt_t got another field just before the errors field, which was missing, thus the errors field in our ffi struct was always null because that other field was still null.