### PR TITLE
Clean up trailing whitespace and remove outdated comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean:
 
 unit-tests: $(unit_tests_binary)
 	$^ --sequential --verbose
- 
+
 integration-tests: $(integration_tests_binary)
 	$^ --sequential
 

--- a/ast/_definition_resolver.pony
+++ b/ast/_definition_resolver.pony
@@ -60,7 +60,7 @@ primitive DefinitionResolver
     | TokenIds.tk_paramref() => _data_ast(ast)
     // functions, behaviours and constructors
     // these don't have a reference to the definition
-    // in their data field - but we can look them up 
+    // in their data field - but we can look them up
     // via their types symbol table
     | TokenIds.tk_funref() | TokenIds.tk_beref()
     | TokenIds.tk_newref() | TokenIds.tk_newberef()

--- a/ast/_num.pony
+++ b/ast/_num.pony
@@ -44,7 +44,7 @@ primitive _Num
       c = try src(offset)? else return offset - 1 end
     end
     offset - 1
-  
+
   fun float(src: String box, start_offset: USize): USize =>
     """returns the offset of the last character of the float in src at start_offset"""
     // integer base 10
@@ -52,7 +52,7 @@ primitive _Num
     //Debug("integral part end: " + offset.string())
 
     offset = offset + 1
-    
+
     // optional point + significand
     var c = try src(offset)? else return offset - 1 end
     if c == U8('.') then
@@ -89,10 +89,10 @@ class iso _FloatTest is UnitTest
   fun apply(h: TestHelper) =>
     var res = _Num.float("12345", 0)
     h.assert_eq[USize](4, res)
-    
+
     res = _Num.float("12345.67890e+12345", 0)
     h.assert_eq[USize](17, res)
-    
+
 class iso _IntTest is UnitTest
   fun name(): String => "num/int"
   fun apply(h: TestHelper) =>

--- a/ast/_stringtab.pony
+++ b/ast/_stringtab.pony
@@ -28,7 +28,5 @@ primitive StringTab
     let str_ptr = string.cpointer()
     recover
       let ptr = @stringtab_len(str_ptr, len)
-      String.from_cpointer(ptr, len) 
+      String.from_cpointer(ptr, len)
     end
-
-

--- a/ast/_symtab.pony
+++ b/ast/_symtab.pony
@@ -40,7 +40,7 @@ struct SymStatus
   new ref create() => None
 
   fun box string(): String iso^ =>
-    recover iso 
+    recover iso
       String.create() .> append(match status
       | SymStati.none() => "NONE"
       | SymStati.nocase() => "NO_CASE"
@@ -87,7 +87,7 @@ class ref SymbolTable
     else
       AST(ptr')
     end
-    
+
   fun box size(): USize =>
     @symtab_size(ptr)
 
@@ -132,5 +132,3 @@ class _SymbolTableIter[S: SymbolTable #read] is Iterator[(String, AST)]
         String.copy_cstring(symbol.name)
       end
     (symbol_name, AST(symbol.def))
-
-

--- a/ast/ast.pony
+++ b/ast/ast.pony
@@ -290,7 +290,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
   fun get(name: String box): (AST | None) =>
     """
     Wrapper around libponyc function `ast_get`
-    
+
     Searching the scope of this AST and all the upper scopes
     for an AST node with the given name.
 
@@ -606,7 +606,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
         // we need to do some complex parsing
         // to get the actual string width including quotes
         let src = (source_contents() as String box)
-        var offset = 
+        var offset =
           if l == 1 then
             col - 1
           else
@@ -630,13 +630,13 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
         while true do
           // check for \" escapes
           match c
-          | '\\' => 
+          | '\\' =>
             // ignore next char and advance
             offset = offset + 1
             c = src(offset)?
             end_col = end_col + 1
             end_quotes = 0
-          | '\n' => 
+          | '\n' =>
             end_line = end_line + 1
             end_col = 1
             end_quotes = 0
@@ -678,7 +678,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
       | TokenIds.tk_float() =>
         // float parsing
         let src = source_contents() as String box
-        let start_offset: USize = 
+        let start_offset: USize =
           if l == 1 then
             col - 1
           else
@@ -737,7 +737,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     Return the definitions of the current node,
     if applicable. Usually there is only one,
     but it is possible to have multiple in some cases.
-    """ 
+    """
     DefinitionResolver.resolve(this)
 
   fun box hash(): USize =>

--- a/ast/errors.pony
+++ b/ast/errors.pony
@@ -155,4 +155,3 @@ struct _Typecheck
     frame = NullablePointer[_TypecheckFrame].none()
     stats = _TypecheckStats.create()
     errors = NullablePointer[_Errors].none()
-

--- a/ast/lexint.pony
+++ b/ast/lexint.pony
@@ -6,7 +6,7 @@ struct _LexIntT
   Compiler internal struct used for parsing numbers from literals in the source code.
   Both for floats, integers.
   For formats hexadecimal, binary and decimal
-  """  
+  """
   let low: U64 = 0
   let high: U64 = 0
 
@@ -33,4 +33,3 @@ struct _LexIntT
 
   fun ref f64(): F64 =>
     @lexint_double(this)
-

--- a/ast/module.pony
+++ b/ast/module.pony
@@ -29,14 +29,14 @@ class val Module is (Hashable & Equatable[Module])
     file = recover val String.copy_cstring(f_ptr) end
     len = source.len
     _hash = @ponyint_hash_block(source.m, len)
-  
+
   fun val create_position_index(): PositionIndex val =>
     PositionIndex.create(this)
 
   fun box hash(): USize =>
     """Return a hash of the file contents"""
     _hash
-    
+
   fun eq(that: box->Module): Bool =>
     """
     Two modules are considered equal if they are from the same file
@@ -311,4 +311,3 @@ class ref _Entry is Comparable[_Entry]
     delegated to Position
     """
     start < other.start
-

--- a/ast/package.pony
+++ b/ast/package.pony
@@ -109,4 +109,3 @@ struct _Package
 
   fun filename(): String val =>
     recover val String.copy_cstring(this._filename) end
-

--- a/ast/pass.pony
+++ b/ast/pass.pony
@@ -90,4 +90,3 @@ struct _PassOpt
   var data: Pointer[None] ref = data.create() // user-defined data for unit test callbacks
 
   new ref create() => None
-

--- a/ast/program.pony
+++ b/ast/program.pony
@@ -1,5 +1,4 @@
 use "lib:ponyc-standalone" if not (openbsd or dragonfly)
-// windows is not supported yet
 use "lib:c++" if osx
 use "files"
 

--- a/ast/program.pony
+++ b/ast/program.pony
@@ -58,4 +58,3 @@ class val Program
     if not ast.raw.is_null() then
       @ast_free(ast.raw)
     end
-

--- a/ast/token.pony
+++ b/ast/token.pony
@@ -537,5 +537,3 @@ primitive TokenIds
       or (token_id == this.tk_interface())
       or (token_id == this.tk_trait())
       or (token_id == this.tk_object())
-
-

--- a/ast/types.pony
+++ b/ast/types.pony
@@ -29,4 +29,3 @@ primitive Types
         ast.ast_type_string()
       end
     end
-

--- a/examples/find_type/find_type.pony
+++ b/examples/find_type/find_type.pony
@@ -113,4 +113,3 @@ actor Main
       | None => None
       end
     end
-

--- a/tests/constructs/main.pony
+++ b/tests/constructs/main.pony
@@ -24,7 +24,7 @@ class Foo is Snot
   var variable: (Array[String] iso | None) = None
   embed s: String = String.create(0b10)
   let immutable: Map[String, USize] = Map[String, USize].create()
- 
+
   fun bla(): U8 => F32(0.12345e-4).u8()
 
   fun with_default(arg: String tag, len: USize = -1) =>


### PR DESCRIPTION

### Changes

- Remove trailing whitespace: cleaned up trailing whitespace from a few files across the project, improving code consistency and reducing unnecessary diff noise in future changes
- Remove outdated Windows-related comment: Windows compilation now works (see #4).

### Consequences

No functional changes - this is purely a code clean up, maintenance PR.
